### PR TITLE
make plugin pre php 7 compliant

### DIFF
--- a/src/Support/ConfigManager.php
+++ b/src/Support/ConfigManager.php
@@ -65,8 +65,8 @@ class ConfigManager
      */
     protected function configure()
     {
-        $this->set('DEBUG', ($this->settings['debug'] ?? null) === 'yes');
-        $this->set('SANDBOX', ($this->settings['sandbox'] ?? null) === 'yes');
+        $this->set('DEBUG', (isset($this->settings['debug']) ? $this->settings['debug'] : null) === 'yes');
+        $this->set('SANDBOX', (isset($this->settings['sandbox']) ? $this->settings['sandbox'] : null) === 'yes');
 
         $this->set('BASE_URL',
             $this->get('SANDBOX') ? 'https://sandbox.simplepay.hu/' : 'https://secure.simplepay.hu/'


### PR DESCRIPTION
Null coalescing operator prevented activation on legacy PHP 5.6.
this change allows the plugin to be activated on such legacy PHP versions