### PR TITLE
Fix 'Notice: Undefined property: stdClass::$checked in Updater.php'

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -53,7 +53,7 @@ class Updater
      */
     public function update($transient)
     {
-        if (! $transient->checked) {
+        if (! isset($transient->checked) || ! $transient->checked) {
             return $transient;
         } elseif (! $response = get_transient('simplepay_update_'.Plugin::SLUG)) {
             $response = wp_remote_get(sprintf($this->url, 'update'));


### PR DESCRIPTION
"Notice: Undefined property: stdClass::$checked in wp-content/plugins/simplepay-gateway-master/src/Updater.php on line 56" error message shows up on the wp-admin pages.
Fixed by adding an `isset()` check.

I'm not sure this is the best fix, I don't really know php, but it works.