### PR TITLE
Add pot file

### DIFF
--- a/languages/pine-simplepay.pot
+++ b/languages/pine-simplepay.pot
@@ -1,0 +1,230 @@
+# Copyright (C) 2020 Pine
+# This file is distributed under the same license as the SimplePay Gateway for WooCommerce plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: SimplePay Gateway for WooCommerce\n"
+"Report-Msgid-Bugs-To: https://github.com/thepinecode/simplepay-gateway/issues/new\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Pine <hello@pineco.de>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 1970-01-01 00:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.4.0\n"
+"X-Domain: pine-simplepay\n"
+
+#. Plugin Name of the plugin
+msgid "SimplePay Gateway for WooCommerce"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://simplepay.conedevelopment.com/"
+msgstr ""
+
+#. Description of the plugin
+msgid "SimplePay gateway integration for WooCommerce."
+msgstr ""
+
+#. Author of the plugin
+msgid "Pine"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://pineco.de"
+msgstr ""
+
+#: includes/fields.php:8
+msgid "Enable SimplePay"
+msgstr ""
+
+#: includes/fields.php:15
+msgid "Credit Card"
+msgstr ""
+
+#: includes/fields.php:22
+msgid "Pay with credit card via SimplePay."
+msgstr ""
+
+#: includes/fields.php:27
+msgid "IPN/IRN settings"
+msgstr ""
+
+#: includes/fields.php:30
+msgid "The shop's IPN/IRN URL:"
+msgstr ""
+
+#: includes/fields.php:36
+msgid "Sandbox Settings"
+msgstr ""
+
+#: includes/fields.php:38
+msgid "If this option is on this gateway is in test (sandbox) mode."
+msgstr ""
+
+#: includes/fields.php:43
+msgid "Enable Sandbox Mode"
+msgstr ""
+
+#: includes/fields.php:48
+msgid "HUF Merchant Settings"
+msgstr ""
+
+#: includes/fields.php:50
+msgid "Settings for HUF currency. These are activated when the customer checks out with HUF prices."
+msgstr ""
+
+#: includes/fields.php:53
+#: includes/fields.php:67
+msgid "HUF Merchant ID"
+msgstr ""
+
+#: includes/fields.php:55
+msgid "This is the merchant ID for HUF currency."
+msgstr ""
+
+#: includes/fields.php:60
+#: includes/fields.php:74
+msgid "HUF Secret Key"
+msgstr ""
+
+#: includes/fields.php:62
+msgid "This is the secret key for HUF currency."
+msgstr ""
+
+#: includes/fields.php:67
+#: includes/fields.php:74
+#: includes/fields.php:101
+#: includes/fields.php:108
+#: includes/fields.php:135
+#: includes/fields.php:142
+msgid "Sandbox"
+msgstr ""
+
+#: includes/fields.php:69
+msgid "This is the sandbox merchant ID for HUF currency."
+msgstr ""
+
+#: includes/fields.php:76
+msgid "This is the sandbox secret key for HUF currency."
+msgstr ""
+
+#: includes/fields.php:82
+msgid "EUR Merchant Settings"
+msgstr ""
+
+#: includes/fields.php:84
+msgid "Settings for EUR currency. These are activated when the customer checks out with EUR prices."
+msgstr ""
+
+#: includes/fields.php:87
+#: includes/fields.php:101
+msgid "EUR Merchant ID"
+msgstr ""
+
+#: includes/fields.php:89
+msgid "This is the merchant ID for EUR currency."
+msgstr ""
+
+#: includes/fields.php:94
+#: includes/fields.php:108
+msgid "EUR Secret Key"
+msgstr ""
+
+#: includes/fields.php:96
+msgid "This is the secret key for EUR currency."
+msgstr ""
+
+#: includes/fields.php:103
+msgid "This is the sandbox merchant ID for EUR currency."
+msgstr ""
+
+#: includes/fields.php:110
+msgid "This is the sandbox secret key for EUR currency."
+msgstr ""
+
+#: includes/fields.php:116
+msgid "USD Merchant Settings"
+msgstr ""
+
+#: includes/fields.php:118
+msgid "Settings for USD currency. These are activated when the customer checks out with USD prices."
+msgstr ""
+
+#: includes/fields.php:121
+#: includes/fields.php:135
+msgid "USD Merchant ID"
+msgstr ""
+
+#: includes/fields.php:123
+msgid "This is the merchant ID for USD currency."
+msgstr ""
+
+#: includes/fields.php:128
+#: includes/fields.php:142
+msgid "USD Secret Key"
+msgstr ""
+
+#: includes/fields.php:130
+msgid "This is the secret key for USD currency."
+msgstr ""
+
+#: includes/fields.php:137
+msgid "This is the sandbox merchant ID for USD currency."
+msgstr ""
+
+#: includes/fields.php:144
+msgid "This is the sandbox secret key for USD currency."
+msgstr ""
+
+#: includes/fields.php:150
+msgid "Debug Settings"
+msgstr ""
+
+#: includes/fields.php:155
+msgid "Debug log"
+msgstr ""
+
+#: includes/fields.php:157
+msgid "Enable logging"
+msgstr ""
+
+#: includes/fields.php:159
+msgid "Log SimplePay events, such as IPN requests, inside log files with the following prefix"
+msgstr ""
+
+#: includes/order-item-row.php:3
+msgid "SimplePay transaction ID"
+msgstr ""
+
+#: src/Gateway.php:169
+msgid "Order not found."
+msgstr ""
+
+#: src/Gateway.php:175
+msgid "Invalid signature."
+msgstr ""
+
+#: src/Handlers/IPNHandler.php:17
+msgid "IPN event was fired."
+msgstr ""
+
+#: src/Handlers/IRNHandler.php:18
+msgid "IRN event was fired."
+msgstr ""
+
+#: src/Handlers/PaymentHandler.php:24
+msgid "You cancelled your transaction."
+msgstr ""
+
+#: src/Handlers/PaymentHandler.php:27
+msgid "Failed SimplePay trasnaction: %d. Please check if your data is correct. If yes, please contact your card publisher."
+msgstr ""
+
+#: src/Handlers/PaymentHandler.php:31
+msgid "The transaction has been expired!"
+msgstr ""
+
+#: src/Plugin.php:64
+msgid "Please activate WooCommerce before using SimplePay Gateway!"
+msgstr ""


### PR DESCRIPTION
Generate with WP-CLI

```bash
wp i18n make-pot . languages/pine-simplepay.pot --skip-js --headers='{"Project-Id-Version": "SimplePay Gateway for WooCommerce", "Report-Msgid-Bugs-To": "https://github.com/thepinecode/simplepay-gateway/issues/new", "Language-Team": "Pine <hello@pineco.de>", "POT-Creation-Date": "1970-01-01 00:00+0000"}'
```

⚠️ 

```
Warning: The string "Failed SimplePay trasnaction: %d. Please check if your data is correct. If yes, please contact your card publisher." 
contains placeholders but has no "translators:" comment to clarify their meaning. (src/Handlers/PaymentHandler.php:27)
```