### PR TITLE
A hash_hmac() fgv csak string-et fogad el

### DIFF
--- a/src/Support/Request.php
+++ b/src/Support/Request.php
@@ -57,7 +57,7 @@ class Request
         $this->url = $url;
         $this->body = $body;
         $this->method = $method;
-        $this->headers = array_merge($this->headers, $headers, ['Signature' => Hash::make($body)]);
+        $this->headers = array_merge($this->headers, $headers, ['Signature' => Hash::make(impode('', $body))]);
     }
 
     /**


### PR DESCRIPTION
```
$ php -r 'var_dump(hash_hmac("sha384", ["apple"], "secret", true));'
PHP Warning:  hash_hmac() expects parameter 2 to be string, array given in Command line code on line 1
NULL
```